### PR TITLE
Fixed victory timer and restart sync

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -13,14 +13,14 @@
   <p>Flags placed: <span id="flagsplaced">0</span>/<span id="flagstotal">?</span></p></br>
   <div id="gameOver">
     <h2 id="gameOverHeader">Game over</h2>
-    <p>Automatic restart in: <span id="time">10</span> s</p> 
+    <p>Automatic restart in: <span id="time"></span>s</p> 
     
     <button onclick="newGame()" type="button">Restart with previous settings<span id="resetbutton"></span></button>
   </div>
   
   <div id="victory">
     <h2 id="victoryHeader">You have won the game</h2>
-    <p>Automatic restart in: <span id="time">10</span></p> 
+    <p>Automatic restart in: <span id="timeV"></span>s</p> 
 
     <button onclick="newGame()" type="button">Restart with previous settings<span id="resetbutton"></span></button>
   </div>
@@ -44,6 +44,7 @@
     var flags = 0;
     var duration = 10;
     var x;
+    var timer = duration, seconds;
     function clicked(x, y) {
       socket.emit('clicked', { x, y });
     }
@@ -63,7 +64,7 @@
     }
     function startTimer(display){
     
-      var timer = duration, seconds;
+      
       x = setInterval(function () {
           
           seconds = parseInt(timer % 60, 10);
@@ -71,10 +72,10 @@
           seconds = seconds < 10 ? "0" + seconds : seconds;
 
           display.textContent =  seconds;
-
-          if (--timer < 0) {
+          console.log(timer);
+          if (--timer <= 0) {
               timer = duration;
-              
+             
               newGame();
           }
       }, 1000);
@@ -102,7 +103,8 @@
         var div = document.getElementById("victory");
         div.style.display = true;
         div.style.display = "block";
-        display = document.querySelector('#time');
+        display = document.querySelector('#timeV');
+        display.textContent =  10;
         startTimer(display);
 
       } else if(gameStatus === -1){
@@ -110,19 +112,30 @@
         div.style.display = true;
         div.style.display = "block";
         display = document.querySelector('#time');
+        display.textContent =  10;
         startTimer(display);
       }
+
     });
     socket.on('new game activated', (newState) => {
       
       console.log('New game activation received:')
       console.log({ newState })
       duration = 10;
+      timer = duration
       clearInterval(x);
       arr = newState;
       ctx = canvas.getContext('2d');
       ctx.canvas.height = arr.length * 21;
       ctx.canvas.width = arr[0].length * 21;
+
+      //clear end screens from other users
+      var div = document.getElementById("gameOver");
+        div.style.display = "none";
+      
+      var div = document.getElementById("victory");
+        div.style.display = "none";
+      
       draw();
     });
 


### PR DESCRIPTION
I could not replicate all the bugs which were brought up in the last meeting, but I fixed what I could. 
Fixed timer on Victory message. It was stuck before.
Fixed issue with game over message syncing, where the game over message was not removed on other instances if the restart button was pressed on one of the instances.